### PR TITLE
This commit allows you to build a single package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD entrypoint.sh /bin/
 ADD abuild.conf /etc/abuild.conf
 RUN mkdir -p /home/builder/package/main/ && chown -R builder /home/builder/
 USER builder
-ENTRYPOINT entrypoint.sh
+ENTRYPOINT ["/bin/entrypoint.sh"]
 WORKDIR /home/builder/package
 ENV PACKAGER_PRIVKEY /home/builder/abuild.rsa
 ADD Dockerfile /alpine-jazz-hands.Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,35 @@
-
 #!/usr/bin/env sh
 
 set -e
 
-main() {
+bootstrap() {
+  echo "bootstrap"
   [ -z "$RSA_PRIVATE_KEY" ] && echo "You need to set RSA_PRIVATE_KEY environent variable" && exit 1
   echo "$RSA_PRIVATE_KEY" > /home/builder/abuild.rsa
   mkdir -p /home/builder/packages
+}
+
+buildall() {
+  "building all packages in /main"
   for d in main/*
   do
     ( cd $d && abuild-apk update && abuild -r )
   done
 }
 
-main "$@"
+build() {
+    echo "Building /main/$1"
+    ( cd main/$1 && abuild-apk update && abuild -r )
+}
+
+echo "$@"
+
+bootstrap "$@"
+if [[ $# -eq 0 ]]; then
+    echo "No args"
+    buildall "$@"
+    exit 0
+fi
+
+build "$1"
 


### PR DESCRIPTION
Currently, if you run alpine-jazz-hands in an aports-like directory
structure it will build all the packages found under /main.

This commit allows you to pass a package name to save building the whole
tree when you're developing.

`docker run alpine-jazz-hands` builds /main/*
`docker run alpine-jazz-hands varnish` builds /main/varnish